### PR TITLE
Fix HoS MOD SOP and arrange entire HoS SOP logically

### DIFF
--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -46,7 +46,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers;
 
-2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray.
+2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray;
 
 3. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
@@ -62,7 +62,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 9. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
-10. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
+10. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
 
 11. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
 
@@ -83,9 +83,9 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 7. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
-8. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
+8. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
 
-9. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
+9. The Head of Security is permitted to wear their Safeguard MODSuit at all times;
 
 10. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray;
 

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -39,7 +39,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 10. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
-11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
+11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
 
 === <span style="color: darkblue">Code Blue</span> ===
 ----
@@ -48,7 +48,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
 
-3. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
+3. The Head of Security is permitted to wear their Safeguard MODSuit at all times;
 
 4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
@@ -90,7 +90,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 10. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
 
-11. The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red. The Captain may perform this duty in the place of the Head of Security.
+11. The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red. The Captain may perform this duty in the place of the Head of Security;
 
 ==[[File:Generic_security.png|32px]][[Security Officer]]==
 

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -87,7 +87,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 9. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
 
-10. Guideline 2 is carried over from Code Blue;
+10. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray;
 
 11. The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red. The Captain may perform this duty in the place of the Head of Security.
 

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -27,7 +27,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In this event, Central Command is to be notified;
 
 6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
@@ -52,7 +52,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In this event, Central Command is to be notified;
 
 6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
@@ -78,7 +78,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In this event, Central Command is to be notified;
 
 6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -46,7 +46,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers;
 
-2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray;
+2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
 
 3. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
@@ -87,7 +87,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 9. The Head of Security is permitted to wear their Safeguard MODSuit at all times;
 
-10. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray;
+10. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
 
 11. The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red. The Captain may perform this duty in the place of the Head of Security.
 

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -39,7 +39,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 10. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
-11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
+11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
 
 === <span style="color: darkblue">Code Blue</span> ===
 ----
@@ -64,7 +64,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 10. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
-11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
+11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
 
 
 === <span style="color: darkred">Code Red</span> ===
@@ -90,7 +90,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 10. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
 
-11. The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red. The Captain may perform this duty in the place of the Head of Security;
+11. The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red. The Captain may perform this duty in the place of the Head of Security.
 
 ==[[File:Generic_security.png|32px]][[Security Officer]]==
 

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -48,13 +48,39 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
 
-3. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
+3. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
 
-4. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
+4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-5. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
 
-6. The Head of Security is not permitted to collect equipment from the Armory to carry on their person;
+6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
+
+7. The Head of Security is not permitted to collect equipment from the Armory to carry on their person;
+
+8. The Head of Security is permitted to either use their regular coat, or armored trenchcoat;
+
+9. The Head of Security is permitted to wear their unique gas mask;
+
+10. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
+
+11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
+
+
+=== <span style="color: darkred">Code Red</span> ===
+----
+
+1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers;
+
+2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
+
+3. The Head of Security is permitted to wear their Safeguard MODSuit at all times;
+
+4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
+
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
+
+6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
 7. The Head of Security is permitted to either use their regular coat, or armored trenchcoat;
 
@@ -63,31 +89,6 @@ For information about deadly force, trials, etc, see [[Space Law]].
 9. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
 10. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
-
-11. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
-
-=== <span style="color: darkred">Code Red</span> ===
-----
-
-1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers;
-
-2. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
-
-3. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
-
-4. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
-
-5. The Head of Security is permitted to either use their regular coat, or armored trenchcoat;
-
-6. The Head of Security is permitted to wear their unique gas mask;
-
-7. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
-
-8. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
-
-9. The Head of Security is permitted to wear their Safeguard MODSuit at all times;
-
-10. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
 
 11. The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red. The Captain may perform this duty in the place of the Head of Security.
 

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -48,25 +48,23 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray.
 
-3. The Head of Security is not permitted to wear their Safeguard MODSuit unless there's an active environmental danger or threat on their life;
+3. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
+4. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
 
-5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
+5. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
-6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
+6. The Head of Security is not permitted to collect equipment from the Armory to carry on their person;
 
-7. The Head of Security is not permitted to collect equipment from the Armory to carry on their person;
+7. The Head of Security is permitted to either use their regular coat, or armored trenchcoat;
 
-8. The Head of Security is permitted to either use their regular coat, or armored trenchcoat;
+8. The Head of Security is permitted to wear their unique gas mask;
 
-9. The Head of Security is permitted to wear their unique gas mask;
+9. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
-10. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
+10. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
 
-11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
-
-12. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
+11. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
 
 === <span style="color: darkred">Code Red</span> ===
 ----

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -66,7 +66,6 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
 
-
 === <span style="color: darkred">Code Red</span> ===
 ----
 
@@ -135,6 +134,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 9. Security Officers may randomly search crewmembers, but are not allowed to apply any degree of force unless said crewmember acts overtly hostile. Crew who refuse to be searched may be stunned and cuffed for the search;
 
 10. Security Officers are permitted to leave prisoners bucklecuffed should they act hostile.
+
 === <span style="color: darkred">Code Red</span> ===
 ----
 


### PR DESCRIPTION
1. Fixes the contradicting MOD suit rules that snuck in with the last change.
2. Arranges the SOP points in the same order across all alert levels to make it easier to read.
3. Changes periods at line ending to semicolons for consistency, except for the last point of an alert level (also consistent with other SOP).
4. Puts the encouragement to carry the unique energy gun back in after it was removed from blue and red (but discouregement kept) and into the same point as other equipment rules. I'm assuming this was the intention and just not spelled out. It's not a suggestion for change if the removal of the encouragement was intentional. If it was intentional, it should probably be spelled out that the HoS is permitted to carry it (and if they are always discouraged from carrying it to write that explicitly too).
5. Grammar change on point 5 (Magistrate interactions)
6. Fixes missing newling between secoff Blue and Red.