### PR TITLE
Adds smith to supply SOP

### DIFF
--- a/sop_supply.wiki
+++ b/sop_supply.wiki
@@ -90,6 +90,20 @@ For a list of regular SOP, or for other departments, see the main page for [[Sta
 
 8. Explorers are required to bring any salvage they find to the Supply Shuttle for selling.
 
+==[[File:Smith.png|32px]][[Smith]]==
+
+1. The Smith is required to deliver at least half of all minerals refined by the Magma Crucible to the Ore Redemption Machine within 20 minutes of the ore being deposited.
+
+2. The Smith is not permitted to hoard minerals. The Ore Redemption Machine must remain stocked with each ore available.
+
+3. The Smith is allowed to sell their products to the crew, not including minerals.
+
+4. The Smith is permitted to use their drill and mining equipment to gather minerals if the Shaft Miners are incapable of doing so, or if there is a lack of Shaft Miners.
+
+5. The Smith is required to follow guidelines 1, 4, 5, and 6 set for Shaft Miners.
+
+6. The Smith is bound by guidelines set for Cargo Technicians when inside the Cargo Office or Bay.
+
 
 {{SOPTable}}
 [[Category:Standard Operating Procedure]]


### PR DESCRIPTION
Adds smith to supply SOP.

The new SOP per our draft in the past is:

1. The Smith is required to deliver at least half of all minerals refined by the Magma Crucible to the Ore Redemption Machine within 20 minutes of the ore being deposited.

2. The Smith is not permitted to hoard minerals. The Ore Redemption Machine must remain stocked with each ore available.

3. The Smith is allowed to sell their products to the crew, not including minerals.

4. The Smith is permitted to use their drill and mining equipment to gather minerals if the Shaft Miners are incapable of doing so, or if there is a lack of Shaft Miners.

5. The Smith is required to follow guidelines 1, 4, 5, and 6 set for Shaft Miners.

6. The Smith is bound by guidelines set for Cargo Technicians when inside the Cargo Office or Bay.