### PR TITLE
Simplification of VoNC

### DIFF
--- a/sop_main.wiki
+++ b/sop_main.wiki
@@ -267,10 +267,6 @@ Along with the guidelines listed below, each and every department has it's own s
 ===Vote of No Confidence===
 {{Hatnote|A Vote of No Confidence is a method for crew to arrange for demotions of unfit command members. It must have a justified reason, detailed below, against the Head of Staff or Captain in question.}}
 
-* Votes have to be verified by a 3rd party who will tally the votes and verify the validity of the reason for it. The 3rd party must be the on-station Captain (unless they are the target of the vote), NT Representative, Magistrate or Centcomm if none of the previous are capable of acting as such. 
-
-* If the 3rd party dismisses the vote reason, the target of the vote must have their authority respected and not be further harassed about it, doing so may result in a demotion for creating an abusive work environment against them. If the department is understaffed or a tie occurs, the 3rd party may participate the vote.
-
 * Votes by departamental crew against their Head of Staff must pass with a 2/3 majority in favor of the vote for it to take effect.
 
 * Votes by Heads of Staff against their Captain must pass a simple majority in favor of the vote for it to take effect.
@@ -279,7 +275,7 @@ Along with the guidelines listed below, each and every department has it's own s
 
 * Unjustified reasons for a vote include but are not limited to; Personal gripes, reasonable and legal disciplining or firing of their staff and denial of permission, among others. 
 
-* If someone is to be demoted by a vote, Centcomm is to be informed afterwards via fax the details, vote count, reasons alongside other relevant information of the demotion. 
+* If a Captain has been demoted by a vote, Centcomm is to be informed afterwards via fax the details, vote count, reasons alongside other relevant information of the demotion. 
 
 }}
 

--- a/sop_main.wiki
+++ b/sop_main.wiki
@@ -271,11 +271,17 @@ Along with the guidelines listed below, each and every department has it's own s
 
 * Votes by Heads of Staff against their Captain must pass a simple majority in favor of the vote for it to take effect.
 
-* Justified reasons for a vote include but are not limited to; 'Causes for Demotion and Dismissal' breaches, Absenteeism, critical lack of communication, abuse of authority and incompetence, among others.
+* Justified reasons for a vote include but are not limited to; 'Causes for Demotion and Dismissal' breaches, absenteeism, critical lack of communication, abuse of authority and incompetence, among others.
 
 * Unjustified reasons for a vote include but are not limited to; Personal gripes, reasonable and legal disciplining or firing of their staff and denial of permission, among others. 
 
-* If a Captain has been demoted by a vote, Centcomm is to be informed afterwards via fax the details, vote count, reasons alongside other relevant information of the demotion. 
+* Any of the involved crew members may request a third party to tally the votes, verify the validity of the vote's justification and oversee the demotion or transfer of power.
+
+* In case of a vote by departamental crew against their Head of Staff, the first member of the following list who is available will be the neutral party: A member of Central Command, the Captain, the Nanotrasen Representative, the Magistrate, any uninvolved Head of Staff, any Internal Affairs Agent, any Security Officer, any uninvolved crew member.
+
+* In case of a vote by Heads of Staff against their Captain, the first member of the following list who is available will be the neutral party: A member of Central Command, the Nanotrasen Representative, the Magistrate, any Internal Affairs Agent, any Security Officer, any uninvolved crew member.
+
+* If a Captain has been demoted by a vote or a third party rejected the outcome of a vote, Central Command is to be informed via fax of the vote count and reasons, alongside other relevant information of the demotion.
 
 }}
 


### PR DESCRIPTION
Lessens requirements for VoNC by only requiring a third party on request, greatly widening the pool of candidates, and only requiring central command to be informed if the VoNC was against the captain.

**Outdated description:**
The formal requirement of having an independent party to verify a VoNC is burdensome and often ignored anyway. It's already difficult enough to get responses from all the people needed for a VoNC, so we don't need to make it any more difficult. When it gets challenged after someoen refuses to comply people can still organically get a third party (in that case probably sec) to count votes.

The requirement to notify centcom for non-captain demotions only really comes (imo) from centcom needing to open a slot, but that's not directly related to VoNC so it doesn't need to be stated in that part of SOP. In other regards, head demotions are Captain and Representative business. (again, imo)