### PR TITLE
Adds Hostage Situation SOP (Properly)

### DIFF
--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -290,5 +290,15 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 11. The Detective is permitted to carry around any weapons or equipment available in the Armory, at the Warden's discretion, but never more than one at a time. Exception is made for severe emergencies, such as Blob Organisms or Nuclear Operatives; 
 
+==Hostage Situations==
+
+1. The Captain is responsible for handling the hostage situation. If the Captain is unavailable, the responsibility falls on the Head of Security; 
+
+2. The Captain may delegate part or all of their authority related to the hostage situation to a designated negotiator. If the Captain is unavailable, the Head of Security should designate a negotiator;
+
+3. Negotiation with the hostage taker should be attempted, unless is it clear that there is no benefit from doing so;
+
+4. The risk to the hostage and other innocent personnel should be minimized. Failure to do so may lead to criminal charges, including Manslaughter.
+
 {{SOPTable}}
 [[Category:Standard Operating Procedure]]

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -27,7 +27,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In this event, Central Command is to be notified;
 
 6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
@@ -46,13 +46,13 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers;
 
-2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray.
+2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
 
-3. The Head of Security is not permitted to wear their Safeguard MODSuit unless there's an active environmental danger or threat on their life;
+3. The Head of Security is permitted to wear their Safeguard MODSuit at all times;
 
 4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In this event, Central Command is to be notified;
 
 6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
@@ -66,30 +66,28 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
 
-12. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
-
 === <span style="color: darkred">Code Red</span> ===
 ----
 
 1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers;
 
-2. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
+2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
 
-3. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
+3. The Head of Security is permitted to wear their Safeguard MODSuit at all times;
 
-4. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
+4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-5. The Head of Security is permitted to either use their regular coat, or armored trenchcoat;
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In this event, Central Command is to be notified;
 
-6. The Head of Security is permitted to wear their unique gas mask;
+6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
-7. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
+7. The Head of Security is permitted to either use their regular coat, or armored trenchcoat;
 
-8. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
+8. The Head of Security is permitted to wear their unique gas mask;
 
-9. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
+9. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
-10. Guideline 2 is carried over from Code Blue;
+10. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
 
 11. The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red. The Captain may perform this duty in the place of the Head of Security.
 
@@ -136,6 +134,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 9. Security Officers may randomly search crewmembers, but are not allowed to apply any degree of force unless said crewmember acts overtly hostile. Crew who refuse to be searched may be stunned and cuffed for the search;
 
 10. Security Officers are permitted to leave prisoners bucklecuffed should they act hostile.
+
 === <span style="color: darkred">Code Red</span> ===
 ----
 

--- a/sop_security.wiki
+++ b/sop_security.wiki
@@ -27,7 +27,7 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In this event, Central Command is to be notified;
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
 
 6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
@@ -46,13 +46,13 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers;
 
-2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
+2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray.
 
-3. The Head of Security is permitted to wear their Safeguard MODSuit at all times;
+3. The Head of Security is not permitted to wear their Safeguard MODSuit unless there's an active environmental danger or threat on their life;
 
 4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In this event, Central Command is to be notified;
+5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
 
 6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
@@ -66,28 +66,30 @@ For information about deadly force, trials, etc, see [[Space Law]].
 
 11. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
 
+12. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
+
 === <span style="color: darkred">Code Red</span> ===
 ----
 
 1. The Head of Security is permitted to carry out arrests under the same conditions as their Security Officers;
 
-2. The Head of Security is permitted to carry a standard disabler, a flash, a telescopic baton, a flashbang, a standard energy gun, and a can of pepperspray. They are permitted and encouraged to carry their unique Energy Gun;
+2. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
 
-3. The Head of Security is permitted to wear their Safeguard MODSuit at all times;
+3. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In which case Central Command is to be contacted as well;
 
-4. The Head of Security is not obligated to provide a trial, but is encouraged to allow legal representation should the suspect request it. This only applies to Capital Crimes;
+4. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
 
-5. The Head of Security may not overrule a Magistrate, unless their decisions are blatantly breaking Standard Operating Procedure and/or Space Law. In this event, Central Command is to be notified;
+5. The Head of Security is permitted to either use their regular coat, or armored trenchcoat;
 
-6. The Head of Security must follow the same guidelines as the Warden for Armory equipment, portable flashers and deployable barriers;
+6. The Head of Security is permitted to wear their unique gas mask;
 
-7. The Head of Security is permitted to either use their regular coat, or armored trenchcoat;
+7. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
 
-8. The Head of Security is permitted to wear their unique gas mask;
+8. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers.
 
-9. The Head of Security may not overrule established sentences, unless further evidence is brought to light or the prisoner in question attempts to escape;
+9. The Head of Security is permitted to wear their Safeguard MODSuit at all times.
 
-10. The Head of Security must follow the same guidelines as Security Officers for attire, with the exception that their own assigned attire is also acceptable for any of the attire mentioned for Security Officers;
+10. Guideline 2 is carried over from Code Blue;
 
 11. The Head of Security is required to make a Station Announcement regarding the nature of the confirmed threat that caused Code Red. The Captain may perform this duty in the place of the Head of Security.
 
@@ -134,7 +136,6 @@ For information about deadly force, trials, etc, see [[Space Law]].
 9. Security Officers may randomly search crewmembers, but are not allowed to apply any degree of force unless said crewmember acts overtly hostile. Crew who refuse to be searched may be stunned and cuffed for the search;
 
 10. Security Officers are permitted to leave prisoners bucklecuffed should they act hostile.
-
 === <span style="color: darkred">Code Red</span> ===
 ----
 


### PR DESCRIPTION
Hostage situations have an infamous habit of ending poorly. Adding soft guidelines around how to handle them is intended to give Security more to work with and encouragement to act out the situation instead of running in first.